### PR TITLE
Enable setting of additional msync arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The ModuleSync `msync` command, which is called by the `concierge` script, uses 
 - `SSH_KNOWN_HOSTS` (default: empty) ... content for the `~/.ssh/known_hosts` file to identify trusted hosts
 - `GIT_USER_NAME`, `GIT_USER_EMAIL` ... override Git user (otherwise derived from last commit)
 - `GIT_COMMIT_MESSAGE` ... override Git commit message (otherwise derived from last commit)
+- `MSYNC_ARGS` define additional arguments to pass to `msync` (e.g. `MSYNC_ARGS=--noop`)
 
 Other environment values can be set as of the official [Git documentation](
 https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables

--- a/concierge.sh
+++ b/concierge.sh
@@ -37,7 +37,7 @@ if [ -d ${CONFIGS} ]; then
         HEADER="=== ${PURPLE}${COMMAND} ${BLUE}${DIRNAME}${NOCOLOR} ==="
 
         echo && echo ${HEADER}
-        cd ${DIR} && ${COMMAND} -m "${GIT_COMMIT_MESSAGE}" || exit $?
+        cd ${DIR} && ${COMMAND} -m "${GIT_COMMIT_MESSAGE}" "${MSYNC_ARGS}" || exit $?
         cd - > /dev/null
     done
 else


### PR DESCRIPTION
Introduce an env var to define additional arguments which are passed to
msync.