### PR TITLE
Use latest modulesync that fixes the v1.3.0 --pr bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/vshn/modulesync:1.3.0
+FROM docker.io/vshn/modulesync:latest
 
 LABEL maintainer="VSHN AG <tech@vshn.ch>"
 


### PR DESCRIPTION
ModuleSync v1.3.0 has a bug that affects the `--pr` option.  See https://github.com/voxpupuli/modulesync/issues/187 for details.

That bug was discovered earlier and a fix was merged into ModuleSync main branch 6 days ago, hence the [vshn/modulesync:latest](https://hub.docker.com/r/vshn/modulesync/) container image contains the fix.

This adaption makes use of the fixed version. We may want to switch back to pinning the image with an appropriate version tag again as soon as a ModuleSync version with the fix is released.